### PR TITLE
Added missing TsItemType values, fixed two

### DIFF
--- a/TsMap/TsTypes.cs
+++ b/TsMap/TsTypes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace TsMap
@@ -70,25 +70,34 @@ namespace TsMap
 
     public enum TsItemType
     {
-        Building = 0x01,
-        Road = 0x03,
-        Prefab = 0x04,
-        Model = 0x05,
-        Company = 0x06,
-        Service = 0x07,
-        CutPlane = 0x08,
-        Dunno = 0x09,
-        City = 0x0C,
-        MapOverlay = 0x12,
-        Ferry = 0x13,
-        Garage = 0x16,
-        Trigger = 0x22,
-        FuelPump = 0x23,
-        RoadSideItem = 0x24,
-        BusStop = 0x25,
-        TrafficRule = 0x26,
-        TrajectoryItem = 0x29,
-        MapArea = 0x2A,
+        Terrain = 1,
+        Building = 2,
+        Road = 3,
+        Prefab = 4,
+        Model = 5,
+        Company = 6,
+        Service = 7,
+        CutPlane = 8,
+        Mover = 9,
+        NoWeather = 11,
+        City = 12,
+        Hinge = 13,
+        MapOverlay = 18,
+        Ferry = 19,
+        Sound = 21,
+        Garage = 22,
+        CameraPoint = 23,
+        Trigger = 34,
+        FuelPump = 35, // services
+        RoadSideItem = 36, // sign
+        BusStop = 37,
+        TrafficRule = 38, // traffic_area
+        BezierPatch = 39,
+        Compound = 40,
+        TrajectoryItem = 41,
+        MapArea = 42,
+        FarModel = 43,
+        Curve = 44
     };
 
 


### PR DESCRIPTION
- Changed TsItemType Enum
-> Fixed item with value 1: That is actually a terrain item, not a building
-> Renamed item with value 9: That is a mover
-> Added comments for existing values that have a different name 
-> Added missing items
-> Changed to decimal values, to make updates easier

---

I got the values in the following way:

- Create `<game folder>/base/map` directories
- Open game with `-editor europe` to start the editor for ETS2 map (`usa` for ATS)
- Type `edit_save_text <map>` in the console
- Go to `<game folder>/base/map/<map>`

Now you have the needed Sector Files (*.aux, *.base) in textual form - it will look like this:

```
SCSAnnotatedFileV1

u32 core_map_version: 876
token game_id: "euro2"
u32 game_map_version: 3
u32 item_count: 1625
array_struct items [
    struct buildings_item {
        struct kdop_item {
            u32 item_type: 2
```

I just searched for `u32 item_type:` and removed the duplicates.