### PR TITLE
Add handling of color indexes used in limited ATS places

### DIFF
--- a/TsMap.Canvas/SimpleMapPalette.cs
+++ b/TsMap.Canvas/SimpleMapPalette.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 
 namespace TsMap.Canvas
 {
@@ -18,6 +18,12 @@ namespace TsMap.Canvas
             FerryLines = new SolidBrush(Color.FromArgb(80, 255, 255, 255));
 
             Error = Brushes.LightCoral;
+
+            SpecialColor8 = new SolidBrush(Color.FromArgb(110, 62, 169));
+            SpecialColor7 = new SolidBrush(Color.FromArgb(236, 212, 36));
+            SpecialColor6 = new SolidBrush(Color.FromArgb(47, 119, 217));
+            SpecialColor5 = new SolidBrush(Color.FromArgb(77, 165, 53));
+            SpecialColor4 = new SolidBrush(Color.FromArgb(153, 0, 0));
         }
     }
 }

--- a/TsMap/MapPalette.cs
+++ b/TsMap/MapPalette.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 
 namespace TsMap
 {
@@ -48,5 +48,30 @@ namespace TsMap
         /// Brush for error text
         /// </summary>
         public Brush Error;
+
+        /// <summary>
+        /// Brush for special color index 8 used in ATS quarry. RGB(110, 62, 169) in game.
+        /// </summary>
+        public Brush SpecialColor8;
+
+        /// <summary>
+        /// Brush for special color index 7 used in ATS quarry. RGB(236, 212, 36) in game.
+        /// </summary>
+        public Brush SpecialColor7;
+
+        /// <summary>
+        /// Brush for special color index 6 used in ATS quarry. RGB(47, 119, 217) in game.
+        /// </summary>
+        public Brush SpecialColor6;
+
+        /// <summary>
+        /// Brush for special color index 5 used in ATS quarry. RGB(77, 165, 53) in game.
+        /// </summary>
+        public Brush SpecialColor5;
+
+        /// <summary>
+        /// Brush for special color index 4 used in ATS quarry. RGB(153, 0, 0) in game.
+        /// </summary>
+        public Brush SpecialColor4;
     }
 }

--- a/TsMap/TsMapRenderer.cs
+++ b/TsMap/TsMapRenderer.cs
@@ -139,23 +139,23 @@ namespace TsMap
 
                     Brush fillColor = palette.PrefabRoad;
                     var zIndex = mapArea.DrawOver ? 10 : 0;
-                    if (mapArea.ColorIndex == 8) {
+                    if ((mapArea.ColorIndex & 0x08) == 8) {
                         // 6e3ea9
                         fillColor = palette.SpecialColor8;
                         zIndex = 100;
-                    } else if (mapArea.ColorIndex == 7) {
+                    } else if ((mapArea.ColorIndex & 0x07) == 7) {
                         // ecd424
                         fillColor = palette.SpecialColor7;
                         zIndex = 100;
-                    } else if (mapArea.ColorIndex == 6) {
+                    } else if ((mapArea.ColorIndex & 0x06) == 6) {
                         // 2f77d9
                         fillColor = palette.SpecialColor6;
                         zIndex = 100;
-                    } else if (mapArea.ColorIndex == 5) {
+                    } else if ((mapArea.ColorIndex & 0x05) == 5) {
                         // 4da535
                         fillColor = palette.SpecialColor5;
                         zIndex = 100;
-                    } else if (mapArea.ColorIndex == 4) {
+                    } else if ((mapArea.ColorIndex & 0x04) == 4) {
                         // 990000
                         fillColor = palette.SpecialColor4;
                         zIndex = 100;

--- a/TsMap/TsMapRenderer.cs
+++ b/TsMap/TsMapRenderer.cs
@@ -139,18 +139,33 @@ namespace TsMap
 
                     Brush fillColor = palette.PrefabRoad;
                     var zIndex = mapArea.DrawOver ? 10 : 0;
-                    if ((mapArea.ColorIndex & 0x03) == 3)
-                    {
+                    if (mapArea.ColorIndex == 8) {
+                        // 6e3ea9
+                        fillColor = palette.SpecialColor8;
+                        zIndex = 100;
+                    } else if (mapArea.ColorIndex == 7) {
+                        // ecd424
+                        fillColor = palette.SpecialColor7;
+                        zIndex = 100;
+                    } else if (mapArea.ColorIndex == 6) {
+                        // 2f77d9
+                        fillColor = palette.SpecialColor6;
+                        zIndex = 100;
+                    } else if (mapArea.ColorIndex == 5) {
+                        // 4da535
+                        fillColor = palette.SpecialColor5;
+                        zIndex = 100;
+                    } else if (mapArea.ColorIndex == 4) {
+                        // 990000
+                        fillColor = palette.SpecialColor4;
+                        zIndex = 100;
+                    } else if ((mapArea.ColorIndex & 0x03) == 3) {
                         fillColor = palette.PrefabGreen;
                         zIndex = mapArea.DrawOver ? 13 : 3;
-                    }
-                    else if ((mapArea.ColorIndex & 0x02) == 2)
-                    {
+                    } else if ((mapArea.ColorIndex & 0x02) == 2) {
                         fillColor = palette.PrefabDark;
                         zIndex = mapArea.DrawOver ? 12 : 2;
-                    }
-                    else if ((mapArea.ColorIndex & 0x01) == 1)
-                    {
+                    } else if ((mapArea.ColorIndex & 0x01) == 1) {
                         fillColor = palette.PrefabLight;
                         zIndex = mapArea.DrawOver ? 11 : 1;
                     }


### PR DESCRIPTION
Some mines in ATS Missouri DLC uses special colors to designate company areas. This PR adds capability to detect such colors in map areas and render them.

Since these colors are only used in MapAreas, I didn't introduce the modified ColorIndex processing to roads and prefabs. Also, z-indexes of colored areas are subject to change.

**Image 1: Map of the company in ATS**
<img width="1036" height="1000" alt="image" src="https://github.com/user-attachments/assets/21955935-6443-40be-9a9b-9db7be96d217" />

**Image 2: Map of the same place in the current version**
<img width="660" height="462" alt="image" src="https://github.com/user-attachments/assets/85379b60-9213-405b-a861-ce5c35c04a30" />

**Image 3: Map of the same place in the proposed version**
<img width="657" height="450" alt="image" src="https://github.com/user-attachments/assets/f09616c7-5e05-437d-bc41-b2c286b289bc" />
